### PR TITLE
feature: anade configuracion de estaticos y templates

### DIFF
--- a/ceic_site/settings.py
+++ b/ceic_site/settings.py
@@ -55,7 +55,7 @@ ROOT_URLCONF = 'ceic_site.urls'
 TEMPLATES = [
     {
         'BACKEND': 'django.template.backends.django.DjangoTemplates',
-        'DIRS': [],
+        'DIRS': [os.path.join(BASE_DIR, 'templates')],
         'APP_DIRS': True,
         'OPTIONS': {
             'context_processors': [


### PR DESCRIPTION
Configuración que permite que la carpeta `templates` y `static` esté en el proyect root